### PR TITLE
WIP: Adds config flag for skipping SSH keygen

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -103,7 +103,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("ui", ui)
 
 	// Only generate the temp key pair if one is not already provided
-	genTempKeyPair := b.config.SSHKeyID == 0 || b.config.Comm.SSHPrivateKeyFile == ""
+	genTempKeyPair := !b.config.SkipKeygen && (b.config.SSHKeyID == 0 || b.config.Comm.SSHPrivateKeyFile == "")
 
 	// Build the steps
 	steps := []multistep.Step{

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -114,6 +114,9 @@ type Config struct {
 	// The ID of an existing SSH key on the DigitalOcean account. This should be
 	// used in conjunction with `ssh_private_key_file`.
 	SSHKeyID int `mapstructure:"ssh_key_id" required:"false"`
+	// Set to true if you are connecting as a non-root user whose public key is
+	// already available on the base image.
+	SkipKeygen bool `mapstructure:"skip_keygen" required:"false"`
 
 	ctx interpolate.Context
 }


### PR DESCRIPTION
WIP

Fixes https://github.com/digitalocean/packer-plugin-digitalocean/issues/132

This PR adds a new config variable to skip the generation of SSH keypairs. This is useful when you do not want to assign SSH keys to the root user (for example if the image you are starting from has existing users with `authorized_keys` set).